### PR TITLE
fix: return native OIDC code when already authenticated

### DIFF
--- a/selfservice/flow/login/error.go
+++ b/selfservice/flow/login/error.go
@@ -5,6 +5,7 @@ package login
 
 import (
 	"net/http"
+	"net/url"
 
 	"go.opentelemetry.io/otel/trace"
 
@@ -128,9 +129,17 @@ func (s *ErrorHandler) WriteFlowError(w http.ResponseWriter, r *http.Request, f 
 		return
 	}
 
-	_, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(r.Context(), f.ID)
+	codes, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(r.Context(), f.ID)
 	if f.Type == flow.TypeAPI && hasCode && group == node.OpenIDConnectGroup {
-		http.Redirect(w, r, f.ReturnTo, http.StatusSeeOther)
+		returnTo, err := url.Parse(f.ReturnTo)
+		if err != nil {
+			s.forward(w, r, f, errors.WithStack(err))
+			return
+		}
+		q := returnTo.Query()
+		q.Set("code", codes.ReturnToCode)
+		returnTo.RawQuery = q.Encode()
+		http.Redirect(w, r, returnTo.String(), http.StatusSeeOther)
 		return
 	}
 

--- a/selfservice/flow/registration/error.go
+++ b/selfservice/flow/registration/error.go
@@ -137,8 +137,21 @@ func (s *ErrorHandler) WriteFlowError(
 		http.Redirect(w, r, f.AppendTo(s.d.Config().SelfServiceFlowRegistrationUI(r.Context())).String(), http.StatusFound)
 		return
 	}
-	if _, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(r.Context(), f.ID); group == node.OpenIDConnectGroup && f.Type == flow.TypeAPI && hasCode {
-		http.Redirect(w, r, f.ReturnTo, http.StatusSeeOther)
+	if codes, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(r.Context(), f.ID); group == node.OpenIDConnectGroup && f.Type == flow.TypeAPI && hasCode {
+		returnTo, err := x.SecureRedirectTo(
+			r,
+			s.d.Config().SelfServiceBrowserDefaultReturnTo(r.Context()),
+			f.SecureRedirectToOpts(r.Context(), s.d)...,
+		)
+		if err != nil {
+			s.forward(w, r, f, errors.WithStack(err))
+			return
+		}
+		q := returnTo.Query()
+		q.Set("code", codes.ReturnToCode)
+		q.Set("flow", f.ID.String())
+		returnTo.RawQuery = q.Encode()
+		http.Redirect(w, r, returnTo.String(), http.StatusSeeOther)
 		return
 	}
 

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -345,19 +345,21 @@ func (s *Strategy) alreadyAuthenticated(ctx context.Context, w http.ResponseWrit
 		if _, ok := f.(*settings.Flow); ok {
 			// ignore this if it's a settings flow
 		} else if !isForced(f) {
-			if flowID, ok := registrationOrLoginFlowID(f); ok {
-				if _, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(ctx, flowID); hasCode {
-					err := s.d.SessionTokenExchangePersister().UpdateSessionOnExchanger(ctx, flowID, sess.ID)
-					if err != nil {
-						return false, err
-					}
-				}
-			}
 			returnTo := s.d.Config().SelfServiceBrowserDefaultReturnTo(ctx)
 			if redirecter, ok := f.(flow.FlowWithRedirect); ok {
 				r, err := x.SecureRedirectTo(r, returnTo, redirecter.SecureRedirectToOpts(ctx, s.d)...)
 				if err == nil {
 					returnTo = r
+				}
+			}
+			if flowID, ok := registrationOrLoginFlowID(f); ok {
+				if codes, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(ctx, flowID); hasCode {
+					if err := s.d.SessionTokenExchangePersister().UpdateSessionOnExchanger(ctx, flowID, sess.ID); err != nil {
+						return false, err
+					}
+					q := returnTo.Query()
+					q.Set("code", codes.ReturnToCode)
+					returnTo.RawQuery = q.Encode()
 				}
 			}
 			http.Redirect(w, r, returnTo.String(), http.StatusSeeOther)

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -885,6 +885,52 @@ func TestStrategy(t *testing.T) {
 				tc.then(t)
 			})
 		}
+		t.Run("case=should return exchange code even if already authenticated", func(t *testing.T) {
+			subject = "existing-session-api-code-testing@ory.sh"
+			jar := x.Must(cookiejar.New(nil))
+
+			t.Run("step=register and create a session", func(t *testing.T) {
+				returnTo := "/foo"
+				r := newBrowserLoginFlow(t, fmt.Sprintf("%s?return_to=%s", returnTS.URL, returnTo), time.Minute)
+				action := assertFormValues(t, r.ID, "valid")
+
+				res, body := makeRequestWithCookieJar(t, "valid", action, url.Values{}, jar, nil)
+				assert.True(t, strings.HasSuffix(res.Request.URL.String(), returnTo))
+				assertIdentity(t, res, body)
+			})
+
+			t.Run("step=perform login and get exchange code", func(t *testing.T) {
+				f := newAPILoginFlow(t, returnTS.URL+"?return_session_token_exchange_code=true&return_to=/app_code", 1*time.Minute)
+
+				_, err := exchangeCodeForToken(t, sessiontokenexchange.Codes{InitCode: f.SessionTokenExchangeCode})
+				require.Error(t, err)
+
+				action := assertFormValues(t, f.ID, "valid")
+				res, err := http.Post(action, "application/json", strings.NewReader(fmt.Sprintf(`{
+	"method": "oidc",
+	"provider": %q
+}`, "valid")))
+				require.NoError(t, err)
+				require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
+				var changeLocation flow.BrowserLocationChangeRequiredError
+				require.NoError(t, json.NewDecoder(res.Body).Decode(&changeLocation))
+
+				res, err = testhelpers.NewClientWithCookieJar(t, jar, nil).Get(changeLocation.RedirectBrowserTo)
+				require.NoError(t, err)
+
+				returnToURL := res.Request.URL
+				returnToCode := returnToURL.Query().Get("code")
+				assert.NotEmpty(t, returnToCode, "code query param was empty in the return_to URL")
+
+				codeResponse, err := exchangeCodeForToken(t, sessiontokenexchange.Codes{
+					InitCode:     f.SessionTokenExchangeCode,
+					ReturnToCode: returnToCode,
+				})
+				require.NoError(t, err)
+				assert.NotEmpty(t, codeResponse.Token)
+				assert.Equal(t, subject, gjson.GetBytes(codeResponse.Session.Identity.Traits, "subject").String())
+			})
+		})
 		t.Run("case=should use redirect_to URL on failure", func(t *testing.T) {
 			ctx := context.Background()
 			subject = "existing-subject-api-code-testing@ory.sh"


### PR DESCRIPTION
Backports the upstream native OIDC fixes needed for desktop social sign-in on our `v1.3.0-gn-v4` line.

This PR intentionally replaces the earlier local stopgap with the upstream-aligned behavior only.

Included upstream behavior:
- https://github.com/ory/kratos/pull/3893
- https://github.com/ory/kratos/pull/4286

Scope is limited to:
- `selfservice/strategy/oidc/strategy.go`
- `selfservice/strategy/oidc/strategy_test.go`
- `selfservice/flow/login/error.go`
- `selfservice/flow/registration/error.go`

Why:
- desktop native callback currently returns bare `return_to` without `code`
- app receives `com.goodnotes.pd.frontend://auth/callback?state=...&provider=google`
- this prevents `/sessions/token-exchange`

Validation:
- `gofmt`
- `git diff --check`
- targeted OIDC tests were started locally, but the suite did not finish in this environment due to the heavy bootstrap/setup path, so no green local Go test run is claimed here