### PR TITLE
fix: identity updated_at

### DIFF
--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -677,6 +677,22 @@ func TestManager(t *testing.T) {
 			// That is why we only check the identity in the store.
 			checkExtensionFields(fromStore, "email-updatetraits-1@ory.sh")(t)
 		})
+
+		t.Run("case=should always update updated_at field", func(t *testing.T) {
+			original := identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
+			original.Traits = newTraits("email-updatetraits-3@ory.sh", "")
+			require.NoError(t, reg.IdentityManager().Create(ctx, original))
+
+			time.Sleep(time.Millisecond)
+
+			require.NoError(t, reg.IdentityManager().UpdateTraits(
+				ctx, original.ID, newTraits("email-updatetraits-4@ory.sh", ""),
+				identity.ManagerAllowWriteProtectedTraits))
+
+			updated, err := reg.IdentityPool().GetIdentity(ctx, original.ID, identity.ExpandNothing)
+			require.NoError(t, err)
+			assert.NotEqual(t, original.UpdatedAt, updated.UpdatedAt, "UpdatedAt field should be updated")
+		})
 	})
 
 	t.Run("method=RefreshAvailableAAL", func(t *testing.T) {

--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -678,21 +678,6 @@ func TestManager(t *testing.T) {
 			checkExtensionFields(fromStore, "email-updatetraits-1@ory.sh")(t)
 		})
 
-		t.Run("case=should always update updated_at field", func(t *testing.T) {
-			original := identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
-			original.Traits = newTraits("email-updatetraits-3@ory.sh", "")
-			require.NoError(t, reg.IdentityManager().Create(ctx, original))
-
-			time.Sleep(time.Millisecond)
-
-			require.NoError(t, reg.IdentityManager().UpdateTraits(
-				ctx, original.ID, newTraits("email-updatetraits-4@ory.sh", ""),
-				identity.ManagerAllowWriteProtectedTraits))
-
-			updated, err := reg.IdentityPool().GetIdentity(ctx, original.ID, identity.ExpandNothing)
-			require.NoError(t, err)
-			assert.NotEqual(t, original.UpdatedAt, updated.UpdatedAt, "UpdatedAt field should be updated")
-		})
 	})
 
 	t.Run("method=RefreshAvailableAAL", func(t *testing.T) {

--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -677,7 +677,6 @@ func TestManager(t *testing.T) {
 			// That is why we only check the identity in the store.
 			checkExtensionFields(fromStore, "email-updatetraits-1@ory.sh")(t)
 		})
-
 	})
 
 	t.Run("method=RefreshAvailableAAL", func(t *testing.T) {

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -1072,6 +1072,7 @@ func (p *IdentityPersister) UpdateIdentity(ctx context.Context, i *identity.Iden
 	}
 
 	i.NID = p.NetworkID(ctx)
+	i.UpdatedAt = time.Now().UTC().Truncate(time.Microsecond)
 	if err := sqlcon.HandleError(p.Transaction(ctx, func(ctx context.Context, tx *pop.Connection) error {
 		// This returns "ErrNoRows" if the identity does not exist
 		if err := update.Generic(WithTransaction(ctx, tx), tx, p.r.Tracer(ctx).Tracer(), i); err != nil {


### PR DESCRIPTION
## Summary
- backport the generic `identities.updated_at` fix onto `ms-native-login`
- `ms-native-login` is the forked release branch used to produce the patched GoodNotes versions
- set `i.UpdatedAt` before persisting identity updates
- truncate the timestamp to microsecond precision to match database storage

## Upstream
- ory/kratos#4131
- ory/kratos#4149