### PR TITLE
fix: merge ms-native-login backports into goodnotes (v7)

### DIFF
--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -677,6 +677,22 @@ func TestManager(t *testing.T) {
 			// That is why we only check the identity in the store.
 			checkExtensionFields(fromStore, "email-updatetraits-1@ory.sh")(t)
 		})
+
+		t.Run("case=should always update updated_at field", func(t *testing.T) {
+			original := identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
+			original.Traits = newTraits("email-updatetraits-3@ory.sh", "")
+			require.NoError(t, reg.IdentityManager().Create(ctx, original))
+
+			time.Sleep(time.Millisecond)
+
+			require.NoError(t, reg.IdentityManager().UpdateTraits(
+				ctx, original.ID, newTraits("email-updatetraits-4@ory.sh", ""),
+				identity.ManagerAllowWriteProtectedTraits))
+
+			updated, err := reg.IdentityPool().GetIdentity(ctx, original.ID, identity.ExpandNothing)
+			require.NoError(t, err)
+			assert.NotEqual(t, original.UpdatedAt, updated.UpdatedAt, "UpdatedAt field should be updated")
+		})
 	})
 
 	t.Run("method=RefreshAvailableAAL", func(t *testing.T) {

--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -678,21 +678,6 @@ func TestManager(t *testing.T) {
 			checkExtensionFields(fromStore, "email-updatetraits-1@ory.sh")(t)
 		})
 
-		t.Run("case=should always update updated_at field", func(t *testing.T) {
-			original := identity.NewIdentity(config.DefaultIdentityTraitsSchemaID)
-			original.Traits = newTraits("email-updatetraits-3@ory.sh", "")
-			require.NoError(t, reg.IdentityManager().Create(ctx, original))
-
-			time.Sleep(time.Millisecond)
-
-			require.NoError(t, reg.IdentityManager().UpdateTraits(
-				ctx, original.ID, newTraits("email-updatetraits-4@ory.sh", ""),
-				identity.ManagerAllowWriteProtectedTraits))
-
-			updated, err := reg.IdentityPool().GetIdentity(ctx, original.ID, identity.ExpandNothing)
-			require.NoError(t, err)
-			assert.NotEqual(t, original.UpdatedAt, updated.UpdatedAt, "UpdatedAt field should be updated")
-		})
 	})
 
 	t.Run("method=RefreshAvailableAAL", func(t *testing.T) {

--- a/identity/manager_test.go
+++ b/identity/manager_test.go
@@ -677,7 +677,6 @@ func TestManager(t *testing.T) {
 			// That is why we only check the identity in the store.
 			checkExtensionFields(fromStore, "email-updatetraits-1@ory.sh")(t)
 		})
-
 	})
 
 	t.Run("method=RefreshAvailableAAL", func(t *testing.T) {

--- a/persistence/sql/identity/persister_identity.go
+++ b/persistence/sql/identity/persister_identity.go
@@ -1072,6 +1072,7 @@ func (p *IdentityPersister) UpdateIdentity(ctx context.Context, i *identity.Iden
 	}
 
 	i.NID = p.NetworkID(ctx)
+	i.UpdatedAt = time.Now().UTC().Truncate(time.Microsecond)
 	if err := sqlcon.HandleError(p.Transaction(ctx, func(ctx context.Context, tx *pop.Connection) error {
 		// This returns "ErrNoRows" if the identity does not exist
 		if err := update.Generic(WithTransaction(ctx, tx), tx, p.r.Tracer(ctx).Tracer(), i); err != nil {

--- a/selfservice/flow/login/error.go
+++ b/selfservice/flow/login/error.go
@@ -5,6 +5,7 @@ package login
 
 import (
 	"net/http"
+	"net/url"
 
 	"go.opentelemetry.io/otel/trace"
 
@@ -128,9 +129,17 @@ func (s *ErrorHandler) WriteFlowError(w http.ResponseWriter, r *http.Request, f 
 		return
 	}
 
-	_, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(r.Context(), f.ID)
+	codes, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(r.Context(), f.ID)
 	if f.Type == flow.TypeAPI && hasCode && group == node.OpenIDConnectGroup {
-		http.Redirect(w, r, f.ReturnTo, http.StatusSeeOther)
+		returnTo, err := url.Parse(f.ReturnTo)
+		if err != nil {
+			s.forward(w, r, f, errors.WithStack(err))
+			return
+		}
+		q := returnTo.Query()
+		q.Set("code", codes.ReturnToCode)
+		returnTo.RawQuery = q.Encode()
+		http.Redirect(w, r, returnTo.String(), http.StatusSeeOther)
 		return
 	}
 

--- a/selfservice/flow/registration/error.go
+++ b/selfservice/flow/registration/error.go
@@ -137,8 +137,21 @@ func (s *ErrorHandler) WriteFlowError(
 		http.Redirect(w, r, f.AppendTo(s.d.Config().SelfServiceFlowRegistrationUI(r.Context())).String(), http.StatusFound)
 		return
 	}
-	if _, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(r.Context(), f.ID); group == node.OpenIDConnectGroup && f.Type == flow.TypeAPI && hasCode {
-		http.Redirect(w, r, f.ReturnTo, http.StatusSeeOther)
+	if codes, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(r.Context(), f.ID); group == node.OpenIDConnectGroup && f.Type == flow.TypeAPI && hasCode {
+		returnTo, err := x.SecureRedirectTo(
+			r,
+			s.d.Config().SelfServiceBrowserDefaultReturnTo(r.Context()),
+			f.SecureRedirectToOpts(r.Context(), s.d)...,
+		)
+		if err != nil {
+			s.forward(w, r, f, errors.WithStack(err))
+			return
+		}
+		q := returnTo.Query()
+		q.Set("code", codes.ReturnToCode)
+		q.Set("flow", f.ID.String())
+		returnTo.RawQuery = q.Encode()
+		http.Redirect(w, r, returnTo.String(), http.StatusSeeOther)
 		return
 	}
 

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -345,19 +345,21 @@ func (s *Strategy) alreadyAuthenticated(ctx context.Context, w http.ResponseWrit
 		if _, ok := f.(*settings.Flow); ok {
 			// ignore this if it's a settings flow
 		} else if !isForced(f) {
-			if flowID, ok := registrationOrLoginFlowID(f); ok {
-				if _, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(ctx, flowID); hasCode {
-					err := s.d.SessionTokenExchangePersister().UpdateSessionOnExchanger(ctx, flowID, sess.ID)
-					if err != nil {
-						return false, err
-					}
-				}
-			}
 			returnTo := s.d.Config().SelfServiceBrowserDefaultReturnTo(ctx)
 			if redirecter, ok := f.(flow.FlowWithRedirect); ok {
 				r, err := x.SecureRedirectTo(r, returnTo, redirecter.SecureRedirectToOpts(ctx, s.d)...)
 				if err == nil {
 					returnTo = r
+				}
+			}
+			if flowID, ok := registrationOrLoginFlowID(f); ok {
+				if codes, hasCode, _ := s.d.SessionTokenExchangePersister().CodeForFlow(ctx, flowID); hasCode {
+					if err := s.d.SessionTokenExchangePersister().UpdateSessionOnExchanger(ctx, flowID, sess.ID); err != nil {
+						return false, err
+					}
+					q := returnTo.Query()
+					q.Set("code", codes.ReturnToCode)
+					returnTo.RawQuery = q.Encode()
 				}
 			}
 			http.Redirect(w, r, returnTo.String(), http.StatusSeeOther)

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -885,6 +885,52 @@ func TestStrategy(t *testing.T) {
 				tc.then(t)
 			})
 		}
+		t.Run("case=should return exchange code even if already authenticated", func(t *testing.T) {
+			subject = "existing-session-api-code-testing@ory.sh"
+			jar := x.Must(cookiejar.New(nil))
+
+			t.Run("step=register and create a session", func(t *testing.T) {
+				returnTo := "/foo"
+				r := newBrowserLoginFlow(t, fmt.Sprintf("%s?return_to=%s", returnTS.URL, returnTo), time.Minute)
+				action := assertFormValues(t, r.ID, "valid")
+
+				res, body := makeRequestWithCookieJar(t, "valid", action, url.Values{}, jar, nil)
+				assert.True(t, strings.HasSuffix(res.Request.URL.String(), returnTo))
+				assertIdentity(t, res, body)
+			})
+
+			t.Run("step=perform login and get exchange code", func(t *testing.T) {
+				f := newAPILoginFlow(t, returnTS.URL+"?return_session_token_exchange_code=true&return_to=/app_code", 1*time.Minute)
+
+				_, err := exchangeCodeForToken(t, sessiontokenexchange.Codes{InitCode: f.SessionTokenExchangeCode})
+				require.Error(t, err)
+
+				action := assertFormValues(t, f.ID, "valid")
+				res, err := http.Post(action, "application/json", strings.NewReader(fmt.Sprintf(`{
+	"method": "oidc",
+	"provider": %q
+}`, "valid")))
+				require.NoError(t, err)
+				require.Equal(t, http.StatusUnprocessableEntity, res.StatusCode)
+				var changeLocation flow.BrowserLocationChangeRequiredError
+				require.NoError(t, json.NewDecoder(res.Body).Decode(&changeLocation))
+
+				res, err = testhelpers.NewClientWithCookieJar(t, jar, nil).Get(changeLocation.RedirectBrowserTo)
+				require.NoError(t, err)
+
+				returnToURL := res.Request.URL
+				returnToCode := returnToURL.Query().Get("code")
+				assert.NotEmpty(t, returnToCode, "code query param was empty in the return_to URL")
+
+				codeResponse, err := exchangeCodeForToken(t, sessiontokenexchange.Codes{
+					InitCode:     f.SessionTokenExchangeCode,
+					ReturnToCode: returnToCode,
+				})
+				require.NoError(t, err)
+				assert.NotEmpty(t, codeResponse.Token)
+				assert.Equal(t, subject, gjson.GetBytes(codeResponse.Session.Identity.Traits, "subject").String())
+			})
+		})
 		t.Run("case=should use redirect_to URL on failure", func(t *testing.T) {
 			ctx := context.Background()
 			subject = "existing-subject-api-code-testing@ory.sh"


### PR DESCRIPTION
## Summary
- `v1.3.0-gn-v6` was cut from the `goodnotes` branch, which never received the two fixes merged into `ms-native-login` via #4 (`MNA-3997-patch-updated-at`):
  - `61d6a90aa` fix(oidc): backport native return_to code handling (#2) — appends the session-token-exchange `code` (and `flow` id) to `return_to` redirects for native/API OIDC login and registration flows, including the already-authenticated case.
  - `9a46498a8` fix: backport identity updated_at fixes — always bumps `updated_at` on `UpdateIdentity`, backporting upstream Kratos #4131/#4149.
- This PR merges `v1.3.0-gn-v5` (tip of `ms-native-login`) into a new branch cut from `v1.3.0-gn-v6` (tip of `goodnotes`), reconciling both branches so neither set of fixes is silently dropped going forward.
- Merge was clean (only `persistence/sql/identity/persister_identity.go` touched by both sides, in different, non-overlapping spots).

## Test plan
- [ ] `go build ./...`
- [ ] `go test ./persistence/... ./selfservice/strategy/oidc/... ./identity/...`
- [ ] Confirm `persister_identity.go` still has both the no-rollback-on-partial-insert fix and the `UpdatedAt = time.Now()` fix
- [ ] Tag as `v1.3.0-gn-v7` once merged