### PR TITLE
amartinj/MNA-5274 reject linking mismatch

### DIFF
--- a/cmd/clidoc/main.go
+++ b/cmd/clidoc/main.go
@@ -173,7 +173,7 @@ func init() {
 		"NewInfoSelfServiceLoginCode":                             text.NewInfoSelfServiceLoginCode(),
 		"NewErrorValidationRegistrationRetrySuccessful":           text.NewErrorValidationRegistrationRetrySuccessful(),
 		"NewInfoSelfServiceRegistrationRegisterCode":              text.NewInfoSelfServiceRegistrationRegisterCode(),
-		"NewErrorValidationLoginLinkedCredentialsDoNotMatch":      text.NewErrorValidationLoginLinkedCredentialsDoNotMatch(),
+		"NewErrorValidationLoginLinkedCredentialsDoNotMatch":      text.NewErrorValidationLoginLinkedCredentialsDoNotMatch("{duplicateIdentifier}", []string{"{available_credential_types_list}"}, []string{"{available_oidc_providers_list}"}),
 		"NewErrorValidationAddressUnknown":                        text.NewErrorValidationAddressUnknown(),
 		"NewInfoSelfServiceLoginCodeMFA":                          text.NewInfoSelfServiceLoginCodeMFA(),
 		"NewInfoLoginPassword":                                    text.NewInfoLoginPassword(),

--- a/schema/errors.go
+++ b/schema/errors.go
@@ -359,13 +359,13 @@ func NewLoginCodeInvalid() error {
 	})
 }
 
-func NewLinkedCredentialsDoNotMatch() error {
+func NewLinkedCredentialsDoNotMatch(dupIdentifier string, availableCredentials, availableProviders []string) error {
 	return errors.WithStack(&ValidationError{
 		ValidationError: &jsonschema.ValidationError{
 			Message:     `linked credentials do not match; please start a new flow`,
 			InstancePtr: "#/",
 		},
-		Messages: new(text.Messages).Add(text.NewErrorValidationLoginLinkedCredentialsDoNotMatch()),
+		Messages: new(text.Messages).Add(text.NewErrorValidationLoginLinkedCredentialsDoNotMatch(dupIdentifier, availableCredentials, availableProviders)),
 	})
 }
 

--- a/selfservice/flow/duplicate_credentials.go
+++ b/selfservice/flow/duplicate_credentials.go
@@ -19,6 +19,13 @@ type DuplicateCredentialsData struct {
 	CredentialsType     identity.CredentialsType
 	CredentialsConfig   sqlxx.JSONRawMessage
 	DuplicateIdentifier string
+
+	// AvailableCredentialTypes and AvailableProviders record the ways the existing
+	// account can be verified. They are needed to re-render the account-linking
+	// screen after a failed verification attempt, which would otherwise come back
+	// without any verification options at all.
+	AvailableCredentialTypes []string
+	AvailableProviders       []string
 }
 
 type InternalContexter interface {

--- a/selfservice/flow/duplicate_credentials_test.go
+++ b/selfservice/flow/duplicate_credentials_test.go
@@ -1,0 +1,87 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package flow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/kratos/identity"
+	"github.com/ory/x/sqlxx"
+)
+
+// fakeInternalContexter is a minimal InternalContexter for testing
+// SetDuplicateCredentials/DuplicateCredentials without a full flow type.
+type fakeInternalContexter struct {
+	ctx sqlxx.JSONRawMessage
+}
+
+func (f *fakeInternalContexter) EnsureInternalContext() {
+	if len(f.ctx) == 0 {
+		f.ctx = sqlxx.JSONRawMessage(`{}`)
+	}
+}
+
+func (f *fakeInternalContexter) GetInternalContext() sqlxx.JSONRawMessage {
+	return f.ctx
+}
+
+func (f *fakeInternalContexter) SetInternalContext(ctx sqlxx.JSONRawMessage) {
+	f.ctx = ctx
+}
+
+func TestDuplicateCredentialsRoundTrip(t *testing.T) {
+	t.Run("case=no duplicate credentials set", func(t *testing.T) {
+		f := &fakeInternalContexter{}
+		dc, err := DuplicateCredentials(f)
+		require.NoError(t, err)
+		assert.Nil(t, dc)
+	})
+
+	t.Run("case=round-trips available credential types and providers", func(t *testing.T) {
+		f := &fakeInternalContexter{}
+		in := DuplicateCredentialsData{
+			CredentialsType:          identity.CredentialsTypeOIDC,
+			CredentialsConfig:        sqlxx.JSONRawMessage(`{"foo":"bar"}`),
+			DuplicateIdentifier:      "duplicate@ory.sh",
+			AvailableCredentialTypes: []string{"password", "oidc"},
+			AvailableProviders:       []string{"google", "microsoft"},
+		}
+		require.NoError(t, SetDuplicateCredentials(f, in))
+
+		out, err := DuplicateCredentials(f)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		assert.Equal(t, in.CredentialsType, out.CredentialsType)
+		assert.Equal(t, in.DuplicateIdentifier, out.DuplicateIdentifier)
+		assert.Equal(t, in.AvailableCredentialTypes, out.AvailableCredentialTypes)
+		assert.Equal(t, in.AvailableProviders, out.AvailableProviders)
+	})
+
+	t.Run("case=older flows without the new fields decode with empty slices", func(t *testing.T) {
+		// Simulates data persisted before AvailableCredentialTypes/AvailableProviders existed.
+		f := &fakeInternalContexter{}
+		in := DuplicateCredentialsData{
+			CredentialsType:     identity.CredentialsTypeOIDC,
+			DuplicateIdentifier: "legacy@ory.sh",
+		}
+		require.NoError(t, SetDuplicateCredentials(f, in))
+
+		out, err := DuplicateCredentials(f)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		assert.Equal(t, "legacy@ory.sh", out.DuplicateIdentifier)
+		assert.Empty(t, out.AvailableCredentialTypes)
+		assert.Empty(t, out.AvailableProviders)
+	})
+
+	t.Run("case=malformed internal context returns an error", func(t *testing.T) {
+		f := &fakeInternalContexter{ctx: sqlxx.JSONRawMessage(`{"registration_duplicate_credentials":{"CredentialsType":123}}`)}
+		dc, err := DuplicateCredentials(f)
+		assert.Error(t, err)
+		assert.NotNil(t, dc)
+	})
+}

--- a/selfservice/flow/login/hook.go
+++ b/selfservice/flow/login/hook.go
@@ -353,7 +353,7 @@ func (e *HookExecutor) maybeLinkCredentials(ctx context.Context, sess *session.S
 		return nil
 	}
 
-	if err := e.checkDuplicateCredentialsIdentifierMatch(ctx, ident.ID, lc.DuplicateIdentifier); err != nil {
+	if err := e.checkDuplicateCredentialsIdentifierMatch(ctx, ident.ID, lc); err != nil {
 		return err
 	}
 	strategy, err := e.d.AllLoginStrategies().Strategy(lc.CredentialsType)
@@ -377,17 +377,17 @@ func (e *HookExecutor) maybeLinkCredentials(ctx context.Context, sess *session.S
 	return nil
 }
 
-func (e *HookExecutor) checkDuplicateCredentialsIdentifierMatch(ctx context.Context, identityID uuid.UUID, match string) error {
+func (e *HookExecutor) checkDuplicateCredentialsIdentifierMatch(ctx context.Context, identityID uuid.UUID, lc *flow.DuplicateCredentialsData) error {
 	i, err := e.d.PrivilegedIdentityPool().GetIdentityConfidential(ctx, identityID)
 	if err != nil {
 		return err
 	}
 	for _, credentials := range i.Credentials {
 		for _, identifier := range credentials.Identifiers {
-			if identifier == match {
+			if identifier == lc.DuplicateIdentifier {
 				return nil
 			}
 		}
 	}
-	return schema.NewLinkedCredentialsDoNotMatch()
+	return schema.NewLinkedCredentialsDoNotMatch(lc.DuplicateIdentifier, lc.AvailableCredentialTypes, lc.AvailableProviders)
 }

--- a/selfservice/flow/login/hook_test.go
+++ b/selfservice/flow/login/hook_test.go
@@ -344,7 +344,7 @@ func TestLoginExecutor(t *testing.T) {
 						}))
 					}), false, url.Values{})
 					assert.EqualValues(t, http.StatusInternalServerError, res.StatusCode)
-					assert.Equal(t, schema.NewLinkedCredentialsDoNotMatch().Error(), body, "%s", body)
+					assert.Equal(t, schema.NewLinkedCredentialsDoNotMatch("wrong@example.com", nil, nil).Error(), body, "%s", body)
 				})
 			})
 

--- a/selfservice/strategy/oidc/strategy.go
+++ b/selfservice/strategy/oidc/strategy.go
@@ -610,6 +610,13 @@ func (s *Strategy) handleError(ctx context.Context, w http.ResponseWriter, r *ht
 			if dc, err := flow.DuplicateCredentials(lf); err == nil && dc != nil {
 				redirectURL = urlx.CopyWithQuery(redirectURL, url.Values{"no_org_ui": {"true"}})
 				s.populateAccountLinkingUI(ctx, lf, usedProviderID, dc.DuplicateIdentifier, dup.AvailableCredentials(), dup.AvailableOIDCProviders())
+				// Remember the verification options on the flow so that a failed
+				// verification attempt can re-render this screen with them intact.
+				dc.AvailableCredentialTypes = dup.AvailableCredentials()
+				dc.AvailableProviders = dup.AvailableOIDCProviders()
+				if err := flow.SetDuplicateCredentials(lf, *dc); err != nil {
+					return err
+				}
 				if err := s.d.LoginFlowPersister().UpdateLoginFlow(ctx, lf); err != nil {
 					return err
 				}

--- a/selfservice/strategy/oidc/strategy_login.go
+++ b/selfservice/strategy/oidc/strategy_login.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ory/herodot"
 	"github.com/ory/kratos/continuity"
 	"github.com/ory/kratos/identity"
+	"github.com/ory/kratos/schema"
 	"github.com/ory/kratos/selfservice/flow"
 	"github.com/ory/kratos/selfservice/flow/login"
 	"github.com/ory/kratos/selfservice/flow/registration"
@@ -105,6 +106,17 @@ func (s *Strategy) processLogin(ctx context.Context, w http.ResponseWriter, r *h
 	i, c, err := s.d.PrivilegedIdentityPool().FindByCredentialsIdentifier(ctx, identity.CredentialsTypeOIDC, identity.OIDCUniqueID(provider.Config().ID, claims.Subject))
 	if err != nil {
 		if errors.Is(err, sqlcon.ErrNoRows) {
+			// The user is on the account-linking screen, proving ownership of an existing
+			// account. A subject we have never seen before can never satisfy that proof, so
+			// refuse instead of falling through to registration, which would silently create
+			// a second account and sign the user into it.
+			if dc, dcErr := flow.DuplicateCredentials(loginFlow); dcErr != nil {
+				return nil, s.handleError(ctx, w, r, loginFlow, provider.Config().ID, nil, dcErr)
+			} else if dc != nil {
+				return nil, s.handleError(ctx, w, r, loginFlow, provider.Config().ID, nil,
+					schema.NewLinkedCredentialsDoNotMatch(dc.DuplicateIdentifier, dc.AvailableCredentialTypes, dc.AvailableProviders))
+			}
+
 			// If no account was found we're "manually" creating a new registration flow and redirecting the browser
 			// to that endpoint.
 

--- a/selfservice/strategy/oidc/strategy_test.go
+++ b/selfservice/strategy/oidc/strategy_test.go
@@ -1705,6 +1705,120 @@ func TestStrategy(t *testing.T) {
 				checkCredentialsLinked(res, body, identityID, "secondProvider")
 			})
 		})
+
+		// Proving ownership with an OIDC identity we have never seen must be rejected.
+		// Falling through to registration here would silently create a second account
+		// and sign the user into it, abandoning the link the user asked for.
+		t.Run("case=second login is OIDC with an unknown subject", func(t *testing.T) {
+			existing := "linking-unknown-subject@ory.sh"
+			unknown := "linking-never-seen-before@ory.sh"
+			scope = []string{"openid", "offline"}
+
+			t.Run("step=create OIDC identity", func(t *testing.T) {
+				subject = existing
+				r := newRegistrationFlow(t, returnTS.URL, time.Minute, flow.TypeBrowser)
+				action := assertFormValues(t, r.ID, "secondProvider")
+				res, body := makeRequest(t, "secondProvider", action, url.Values{})
+				assertIdentity(t, res, body)
+				expectTokens(t, "secondProvider", body)
+			})
+
+			subject = existing
+			client := testhelpers.NewClientWithCookieJar(t, nil, nil)
+			loginFlow := newLoginFlow(t, returnTS.URL, time.Minute, flow.TypeBrowser)
+			var linkingLoginFlow struct{ ID string }
+
+			t.Run("step=should fail login and start a new login", func(t *testing.T) {
+				conf.MustSet(ctx, config.ViperKeySelfServiceRegistrationLoginHints, true)
+				res, body := loginWithOIDC(t, client, loginFlow.ID, "valid2")
+				assertUIError(t, res, body, "You tried to sign in with \""+existing+"\", but that email is already used by another account.")
+				linkingLoginFlow.ID = gjson.GetBytes(body, "id").String()
+				assert.NotEqual(t, loginFlow.ID.String(), linkingLoginFlow.ID, "should have started a new flow")
+			})
+
+			// The user picks the provider the screen legitimately offers, but signs in
+			// with a different account at the provider than the one being linked.
+			t.Run("step=should reject an unknown subject instead of registering it", func(t *testing.T) {
+				require.NotEmpty(t, linkingLoginFlow.ID)
+				subject = unknown
+				res, body := loginWithOIDC(t, client, uuid.Must(uuid.FromString(linkingLoginFlow.ID)), "secondProvider")
+				assertUIError(t, res, body, "Linked credentials do not match.")
+
+				// The screen must keep offering the ways the existing account can be
+				// verified, otherwise the user is left with no way to continue.
+				assert.Equal(t,
+					strconv.Itoa(int(text.ErrorValidationLoginLinkedCredentialsDoNotMatch)),
+					gjson.GetBytes(body, "ui.messages.0.id").String(),
+					prettyJSON(t, body),
+				)
+				assert.Equal(t, existing,
+					gjson.GetBytes(body, "ui.messages.0.context.duplicate_identifier").String(),
+					prettyJSON(t, body))
+				assert.NotEmpty(t,
+					gjson.GetBytes(body, "ui.messages.0.context.available_credential_types").Array(),
+					prettyJSON(t, body))
+
+				// No account may be created for the unknown subject.
+				_, _, err := reg.PrivilegedIdentityPool().FindByCredentialsIdentifier(ctx,
+					identity.CredentialsTypeOIDC, identity.OIDCUniqueID("secondProvider", unknown))
+				assert.Error(t, err, "an identity was created for the unknown subject")
+			})
+		})
+
+		// The guard reads the flow's persisted linking context before deciding whether
+		// to register. If that context is corrupted, refuse rather than fall through to
+		// registration: this must fail safe, not fail open.
+		t.Run("case=second login is OIDC with a corrupted linking context", func(t *testing.T) {
+			existing := "linking-corrupted-context@ory.sh"
+			unknown := "linking-corrupted-context-unknown@ory.sh"
+			scope = []string{"openid", "offline"}
+
+			t.Run("step=create OIDC identity", func(t *testing.T) {
+				subject = existing
+				r := newRegistrationFlow(t, returnTS.URL, time.Minute, flow.TypeBrowser)
+				action := assertFormValues(t, r.ID, "secondProvider")
+				res, body := makeRequest(t, "secondProvider", action, url.Values{})
+				assertIdentity(t, res, body)
+				expectTokens(t, "secondProvider", body)
+			})
+
+			subject = existing
+			client := testhelpers.NewClientWithCookieJar(t, nil, nil)
+			loginFlow := newLoginFlow(t, returnTS.URL, time.Minute, flow.TypeBrowser)
+			var linkingLoginFlow struct{ ID string }
+
+			t.Run("step=should fail login and start a new login", func(t *testing.T) {
+				conf.MustSet(ctx, config.ViperKeySelfServiceRegistrationLoginHints, true)
+				res, body := loginWithOIDC(t, client, loginFlow.ID, "valid2")
+				assertUIError(t, res, body, "You tried to sign in with \""+existing+"\", but that email is already used by another account.")
+				linkingLoginFlow.ID = gjson.GetBytes(body, "id").String()
+				assert.NotEqual(t, loginFlow.ID.String(), linkingLoginFlow.ID, "should have started a new flow")
+			})
+
+			t.Run("step=should fail safe instead of registering when the linking context cannot be read", func(t *testing.T) {
+				require.NotEmpty(t, linkingLoginFlow.ID)
+
+				lf, err := reg.LoginFlowPersister().GetLoginFlow(ctx, uuid.Must(uuid.FromString(linkingLoginFlow.ID)))
+				require.NoError(t, err)
+				// A type that cannot decode into flow.DuplicateCredentialsData: this is what
+				// flow.DuplicateCredentials sees as corrupted internal context.
+				lf.SetInternalContext(sqlxx.JSONRawMessage(`{"registration_duplicate_credentials":{"CredentialsType":123}}`))
+				require.NoError(t, reg.LoginFlowPersister().UpdateLoginFlow(ctx, lf))
+
+				subject = unknown
+				res, body := loginWithOIDC(t, client, uuid.Must(uuid.FromString(linkingLoginFlow.ID)), "secondProvider")
+
+				// The corrupted context must not be treated as "no linking pending": the
+				// request is rejected onto the generic error page, not the login/linking UI.
+				assert.Contains(t, res.Request.URL.String(), errTS.URL, "%s", body)
+				assert.Contains(t, string(body), "cannot unmarshal", "%s", body)
+
+				// Above all, no account may be created for the unknown subject.
+				_, _, err = reg.PrivilegedIdentityPool().FindByCredentialsIdentifier(ctx,
+					identity.CredentialsTypeOIDC, identity.OIDCUniqueID("secondProvider", unknown))
+				assert.Error(t, err, "an identity was created for the unknown subject despite a corrupted linking context")
+			})
+		})
 	})
 
 	t.Run("method=TestPopulateSignUpMethod", func(t *testing.T) {

--- a/text/message_login.go
+++ b/text/message_login.go
@@ -256,11 +256,16 @@ func NewInfoSelfServiceLoginCode() *Message {
 	}
 }
 
-func NewErrorValidationLoginLinkedCredentialsDoNotMatch() *Message {
+func NewErrorValidationLoginLinkedCredentialsDoNotMatch(dupIdentifier string, availableCredentials, availableProviders []string) *Message {
 	return &Message{
 		ID:   ErrorValidationLoginLinkedCredentialsDoNotMatch,
 		Text: "Linked credentials do not match.",
 		Type: Error,
+		Context: context(map[string]any{
+			"duplicate_identifier":       dupIdentifier,
+			"available_credential_types": availableCredentials,
+			"available_providers":        availableProviders,
+		}),
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes [MNA-5274](https://goodnotes.atlassian.net/browse/MNA-5274): during account linking, authenticating with an OIDC identity that isn't the one being linked doesn't raise an account-mismatch error — the request silently falls through to registration/login as a different, unrelated account, with no error shown and the intended link abandoned.

## Root cause

The linking guard (`maybeLinkCredentials` → `checkDuplicateCredentialsIdentifierMatch`) already existed and is correct — but it's only reachable from the **login** path (`PostLoginHook`). The **registration** path never checked it.

In `strategy_login.go`'s `processLogin`, when an OIDC subject resolves to no existing identity (`sqlcon.ErrNoRows`), the code builds a fresh registration flow and copies several fields (`ReturnTo`, `OAuth2LoginChallenge`, `TransientPayload`, etc.) — but not the internal context, which is where the pending linking state (`registration_duplicate_credentials`) lives. That state silently evaporates, `processRegistration` runs, and a session is issued for an unrelated account.

## Changes

- **`strategy_login.go`** — before falling through to registration, check whether the login flow carries a pending linking context (`flow.DuplicateCredentials`). If it does, refuse with `LinkedCredentialsDoNotMatch` (4010009) instead of registering. No identity is created and no session is issued.
- **`DuplicateCredentialsData`** (`duplicate_credentials.go`) — added `AvailableCredentialTypes`/`AvailableProviders`, populated in `strategy.go`'s `handleError` where they're already computed. Without this, the account-linking screen would re-render with zero verification options after a rejected attempt — a dead end that already affects today's working mismatch case, not just this fix.
- **`NewErrorValidationLoginLinkedCredentialsDoNotMatch`** (`text/message_login.go`) and its wrapper `schema.NewLinkedCredentialsDoNotMatch` — now carry that context (`duplicate_identifier`, `available_credential_types`, `available_providers`), mirroring the sibling `1010016` message. Ripples into `login/hook.go`'s existing call site and `cmd/clidoc/main.go`'s doc-generation map.

No frontend changes needed — AuthWeb's account-linking screen already renders on message `4010009` and already reads this exact context shape.

## Testing

- New integration test: `case=second login is OIDC with an unknown subject` — drives a real OIDC callback with a subject the linking screen never expected, asserts the rejection, and asserts **no identity is created**.
- New integration test: `case=second login is OIDC with a corrupted linking context` — persists genuinely malformed internal-context JSON onto a live flow and drives it through the real callback, proving the code fails *safe* (generic error page) rather than falling open to registration when the context can't even be read.
- New unit test (`duplicate_credentials_test.go`, previously untested file) — round-trip of the new fields, legacy-data decode (empty slices for flows persisted before this change), and the malformed-JSON error path.
- Existing password- and OIDC-linking tests (`case=second login is password`, `case=second login is OIDC`) continue to pass unmodified — confirms no regression to the working linking paths.
- Verified no regression by diffing the full `./selfservice/strategy/oidc/` suite, and separately the whole repo's `-short` unit suite, against an unmodified `v1.3.0-gn-v7` baseline: identical failures on both (all pre-existing, environment-dependent — live DNS behavior for a hardcoded `ory.sh` test fixture, a live HaveIBeenPwned API hit, Microsoft's real OIDC issuer — none touching this diff).

## Release note

Registered but unrelated identities must still not slip past account linking undetected.

[MNA-5274]: https://goodnotes.atlassian.net/browse/MNA-5274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ